### PR TITLE
Adding "--limit" parameter

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,6 +82,11 @@ def get_argparser():
                         help='Drop into ipython shell after test run',
                         action='store_true',
                         default=False)
+    parser.add_argument('-l', '--limit',
+                        help='Limit for number of URLs to test (default: unlimited)',
+                        type=int,
+                        action='store',
+                        default=0)
     parser.add_argument('testset',
                         metavar='TESTSET',
                         help='Test set to run. Use `list` for info. (default: `%s`)' % testset_default,
@@ -277,7 +282,7 @@ def run_tests(args, test_app, base_app):
     sources_dir = os.path.join(module_dir, 'sources')
 
     # Compile the set of URLs to test
-    urldb = us.URLStore(sources_dir)
+    urldb = us.URLStore(sources_dir, limit=args.limit)
     urldb.load(args.testset)
     url_set = set(urldb)
     logger.info("%d URLs in test set" % len(url_set))

--- a/url_store.py
+++ b/url_store.py
@@ -49,9 +49,10 @@ def iter(dataset, data_dir):
 
 
 class URLStore(object):
-    def __init__(self, data_dir):
+    def __init__(self, data_dir, limit=0):
         self.__data_dir = os.path.abspath(data_dir)
         self.__loaded_datasets = []
+        self.__limit = limit
         self.clear()
 
     def clear(self):
@@ -60,11 +61,14 @@ class URLStore(object):
 
     def __len__(self):
         """Returns number of active URLs in store."""
-        return len(self.__urls)
+        if self.__limit > 0:
+            return min(len(self.__urls), self.__limit)
+        else:
+            return len(self.__urls)
 
     def __iter__(self):
         """Iterate all active URLs in store."""
-        for rank, url in self.__urls:
+        for rank, url in self.__urls[:len(self)]:
             yield rank, url
 
     @staticmethod


### PR DESCRIPTION
The new command line option limits the number of URLs processed from
a URL store.

This addresses https://github.com/cr/tls-canary/issues/18