### PR TITLE
Improving OneCRL Go package handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,21 @@ http://tlscanary.mozilla.org
 * Automatically runs thousands of secure sites on those builds.
 * Diffs the results and presents potentially broken sites in an HTML page for further diagnosis.
 
+## Requirements
+* Python 2.7
+* virtualenv (highly recommended)
+* git
+* Go compiler
+
+The script ```linux_bootstrap.sh``` provides bootstrapping for an Ubuntu-based EC2 instance.
+
 ## Usage
+* cd tls-canary
 * virtualenv .
 * source bin/activate
 * pip install -e .
 * tls_canary --help
+* tls_canary --reportdir=/tmp/test --debug debug
 
 ## Testing
 * nosetests -s

--- a/linux_bootstrap.sh
+++ b/linux_bootstrap.sh
@@ -9,4 +9,3 @@ sudo apt-get install python-dev
 sudo apt-get install virtualenv
 sudo apt-get install gcc
 sudo apt-get install golang-go
-cd $(dirname $(which go)) && cd $(dirname $(readlink go)) && cd ../ && sudo chmod 0777 ./src

--- a/main.py
+++ b/main.py
@@ -375,15 +375,16 @@ def make_profiles(args):
     dir_util.copy_tree(default_profile_dir, test_profile_dir)
     dir_util.copy_tree(default_profile_dir, release_profile_dir)
 
+    logger.info("Updating OneCRL revocation data")
     if args.onecrl == 'prod' or args.onecrl == 'stage':
         # overwrite revocations file in test profile with live OneCRL entries from requested environment
-        one_crl.get_list(args.onecrl, test_profile_dir)
+        one_crl.get_list(args.onecrl, test_profile_dir, args.workdir)
     else:
         # leave the existing revocations file alone
         logger.info("Testing with custom OneCRL entries from default profile")
 
     # get live OneCRL entries from production for release profile
-    one_crl.get_list("prod", release_profile_dir)
+    one_crl.get_list("prod", release_profile_dir, args.workdir)
 
     # make all files in profiles read-only to prevent caching
     for root, dirs, files in os.walk(test_profile_dir, topdown=False):

--- a/one_crl_downloader.py
+++ b/one_crl_downloader.py
@@ -2,45 +2,64 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from distutils.spawn import find_executable
 import logging
 import os
+import subprocess
 import sys
 from shutil import rmtree
 
 logger = logging.getLogger(__name__)
 
 
-def get_list(one_crl_environ, workdir):
+def get_list(onecrl_env, profile_dir, workdir):
+    global logger
 
-    # find go installation and create subdirectories
-    locations = os.environ.get("PATH").split(os.pathsep)
-    candidates = []
-    for location in locations:
-        candidate = os.path.join(location, 'go')
-        if os.path.isfile(candidate):
-            candidates.append(candidate)
-    go_orig = candidates[0]
-    go_real_path = os.path.realpath(go_orig)
-    go_src_path = os.path.normpath(go_real_path+"../../../src")
+    # Find Go binary
+    go_bin = find_executable("go")
+    if go_bin is None:
+        logger.critical("Cannot find Go compiler")
+        sys.exit(5)
+    logger.debug("Using Go compiler at `%s`" % go_bin)
 
-    src_dir = os.path.join(go_src_path, "github.com")
-    tmp_dir = os.path.join(src_dir, "mozmark")
-    git_src_path = os.path.join(tmp_dir, "OneCRL-Tools")
+    # Prepare Go environment within our workdir
+    go_path = os.path.join(workdir, "go")
+    logger.debug("Using GOPATH `%s`" % go_path)
+    go_env = os.environ.copy()
+    go_env["GOPATH"] = go_path
 
-    if not os.path.exists(git_src_path):
-        logger.info("Downloading OneCRL tools")
-        os.mkdir(src_dir)
-        os.mkdir(tmp_dir)
-        os.mkdir(git_src_path)
-        # put OneCRL code into this directory
-        git_cmd = "git clone https://github.com/mozmark/OneCRL-Tools %s" % git_src_path
-        os.system(git_cmd)
+    # Install / update oneCRL2RevocationsTxt package
+    package = "github.com/mozmark/OneCRL-Tools/oneCRL2RevocationsTxt"
+    logger.debug("Installing / updating Go package `%s`" % package)
+    if subprocess.call([go_bin, "get", package], env=go_env) != 0:
+        logger.critical("Cannot get Go package `%s`" % package)
+        sys.exit(5)
+    if subprocess.call([go_bin, "install", package], env=go_env) != 0:
+        logger.critical("Cannot install Go package `%s`" % package)
+        sys.exit(5)
 
-    # obtain OneCRL list and write to disk
-    logger.info("Obtaining OneCRL entries from %s and writing to disk " % one_crl_environ)
-    one_crl_app = os.path.join(git_src_path, "oneCRL2RevocationsTxt/main.go")
-    go_cmd = "go run %s %s > %s/revocations.txt" % (one_crl_app, one_crl_environ, workdir)
-    os.system(go_cmd)
+    # Run OneCRL Go binary to retrieve OnceCRL data
+    onecrl_bin = os.path.join(go_path, "bin", "oneCRL2RevocationsTxt")
+    if not os.path.isfile(onecrl_bin):
+        logger.critical("Go package `oneCRL2RevocationsTxt` is missing executable")
+        sys.exit(5)
+    onecrl_cmd = [onecrl_bin, "--env", onecrl_env]
+    logger.debug("Running shell command `%s`" % " ".join(onecrl_cmd))
+    try:
+        revocations_data = subprocess.check_output(onecrl_cmd, env=go_env)
+    except CalledProcessError as error:
+        logger.critical("Could not fetch revocations data: %s" % error)
+        sys.exit(5)
 
-    # optional: remove temporary source directory
-    # rmtree(src_dir)
+    # oneCRL2RevocationsTxt does not indicate failure, but the result is empty.
+    # Can we be sure this can never happen during regular operation?
+    # See https://github.com/mozmark/OneCRL-Tools/issues/3
+    if len(revocations_data) == 0:
+        logger.critical("Revocations data was empty. Likely network failure.")
+        sys.exit(5)
+
+    # Write OneCRL data to file in profile directory
+    revocations_file = os.path.join(profile_dir, "revocations.txt")
+    logger.debug("Writing OneCRL revocations data to `%s`" % revocations_file)
+    with open(revocations_file, "w") as f:
+        f.write(revocations_data)


### PR DESCRIPTION
Moving from manual package installation via git to using the package
handling provided by the go binary.