### PR TITLE
Fixing cert saving issue - path needed trailing slash

### DIFF
--- a/js/scan_url.js
+++ b/js/scan_url.js
@@ -101,7 +101,7 @@ for (var i=0;i<arguments.length;i++)
   }
   if (arguments[i].indexOf("-c=") != -1)
   {
-    certPath = arguments[i].split("-c=")[1];
+    certPath = arguments[i].split("-c=")[1] + "/";
   }
   if (arguments[i].indexOf("-j=") != -1)
   {


### PR DESCRIPTION
All paths passed to our JS script do not have trailing slashes, so let's keep it that way. Instead, I modified the best place in the JS file to add the trailing slash in this case, in order to allow SSL certificate saving to work again.