### PR TITLE
Accelerate one_crl_downloader.py by caching and add Windows support

### DIFF
--- a/main.py
+++ b/main.py
@@ -385,13 +385,19 @@ def make_profiles(args):
     logger.info("Updating OneCRL revocation data")
     if args.onecrl == 'prod' or args.onecrl == 'stage':
         # overwrite revocations file in test profile with live OneCRL entries from requested environment
-        one_crl.get_list(args.onecrl, test_profile_dir, args.workdir)
+        revocations_file = one_crl.get_list(args.onecrl, args.workdir)
+        profile_file = os.path.join(test_profile_dir, "revocations.txt")
+        logger.debug("Writing OneCRL revocations data to `%s`" % profile_file)
+        shutil.copyfile(revocations_file, profile_file)
     else:
         # leave the existing revocations file alone
         logger.info("Testing with custom OneCRL entries from default profile")
 
     # get live OneCRL entries from production for release profile
-    one_crl.get_list("prod", release_profile_dir, args.workdir)
+    revocations_file = one_crl.get_list("prod", args.workdir)
+    profile_file = os.path.join(release_profile_dir, "revocations.txt")
+    logger.debug("Writing OneCRL revocations data to `%s`" % profile_file)
+    shutil.copyfile(revocations_file, profile_file)
 
     # make all files in profiles read-only to prevent caching
     for root, dirs, files in os.walk(test_profile_dir, topdown=False):

--- a/one_crl_downloader.py
+++ b/one_crl_downloader.py
@@ -49,7 +49,10 @@ def get_list(onecrl_env, workdir, use_cache=True, cache_timeout=60*60):
             sys.exit(5)
 
         # Run OneCRL Go binary to retrieve OnceCRL data
-        onecrl_bin = os.path.join(go_path, "bin", "oneCRL2RevocationsTxt")
+        if sys.platform == "win32":
+            onecrl_bin = os.path.join(go_path, "bin", "oneCRL2RevocationsTxt.exe")
+        else:
+            onecrl_bin = os.path.join(go_path, "bin", "oneCRL2RevocationsTxt")
         if not os.path.isfile(onecrl_bin):
             logger.critical("Go package `oneCRL2RevocationsTxt` is missing executable")
             sys.exit(5)

--- a/one_crl_downloader.py
+++ b/one_crl_downloader.py
@@ -7,59 +7,73 @@ import logging
 import os
 import subprocess
 import sys
-from shutil import rmtree
+
+import cache
 
 logger = logging.getLogger(__name__)
 
 
-def get_list(onecrl_env, profile_dir, workdir):
+def get_list(onecrl_env, workdir, use_cache=True, cache_timeout=60*60):
     global logger
 
-    # Find Go binary
-    go_bin = find_executable("go")
-    if go_bin is None:
-        logger.critical("Cannot find Go compiler")
-        sys.exit(5)
-    logger.debug("Using Go compiler at `%s`" % go_bin)
+    dc = cache.DiskCache(os.path.join(workdir, "cache"), cache_timeout, purge=True)
+    cache_id = "%s_revocations.txt" % onecrl_env
+    if not use_cache:
+        # Enforce re-extraction even if cached
+        dc.delete(cache_id)
+    cache_file = dc[cache_id]
 
-    # Prepare Go environment within our workdir
-    go_path = os.path.join(workdir, "go")
-    logger.debug("Using GOPATH `%s`" % go_path)
-    go_env = os.environ.copy()
-    go_env["GOPATH"] = go_path
+    if cache_id not in dc:
 
-    # Install / update oneCRL2RevocationsTxt package
-    package = "github.com/mozmark/OneCRL-Tools/oneCRL2RevocationsTxt"
-    logger.debug("Installing / updating Go package `%s`" % package)
-    if subprocess.call([go_bin, "get", package], env=go_env) != 0:
-        logger.critical("Cannot get Go package `%s`" % package)
-        sys.exit(5)
-    if subprocess.call([go_bin, "install", package], env=go_env) != 0:
-        logger.critical("Cannot install Go package `%s`" % package)
-        sys.exit(5)
+        # Find Go binary
+        go_bin = find_executable("go")
+        if go_bin is None:
+            logger.critical("Cannot find Go compiler")
+            sys.exit(5)
+        logger.debug("Using Go compiler at `%s`" % go_bin)
 
-    # Run OneCRL Go binary to retrieve OnceCRL data
-    onecrl_bin = os.path.join(go_path, "bin", "oneCRL2RevocationsTxt")
-    if not os.path.isfile(onecrl_bin):
-        logger.critical("Go package `oneCRL2RevocationsTxt` is missing executable")
-        sys.exit(5)
-    onecrl_cmd = [onecrl_bin, "--env", onecrl_env]
-    logger.debug("Running shell command `%s`" % " ".join(onecrl_cmd))
-    try:
-        revocations_data = subprocess.check_output(onecrl_cmd, env=go_env)
-    except subprocess.CalledProcessError as error:
-        logger.critical("Could not fetch revocations data: %s" % error)
-        sys.exit(5)
+        # Prepare Go environment within our workdir
+        go_path = os.path.join(workdir, "go")
+        logger.debug("Using GOPATH `%s`" % go_path)
+        go_env = os.environ.copy()
+        go_env["GOPATH"] = go_path
 
-    # oneCRL2RevocationsTxt does not indicate failure, but the result is empty.
-    # Can we be sure this can never happen during regular operation?
-    # See https://github.com/mozmark/OneCRL-Tools/issues/3
-    if len(revocations_data) == 0:
-        logger.critical("Revocations data was empty. Likely network failure.")
-        sys.exit(5)
+        # Install / update oneCRL2RevocationsTxt package
+        package = "github.com/mozmark/OneCRL-Tools/oneCRL2RevocationsTxt"
+        logger.debug("Installing / updating Go package `%s`" % package)
+        if subprocess.call([go_bin, "get", package], env=go_env) != 0:
+            logger.critical("Cannot get Go package `%s`" % package)
+            sys.exit(5)
+        if subprocess.call([go_bin, "install", package], env=go_env) != 0:
+            logger.critical("Cannot install Go package `%s`" % package)
+            sys.exit(5)
 
-    # Write OneCRL data to file in profile directory
-    revocations_file = os.path.join(profile_dir, "revocations.txt")
-    logger.debug("Writing OneCRL revocations data to `%s`" % revocations_file)
-    with open(revocations_file, "w") as f:
-        f.write(revocations_data)
+        # Run OneCRL Go binary to retrieve OnceCRL data
+        onecrl_bin = os.path.join(go_path, "bin", "oneCRL2RevocationsTxt")
+        if not os.path.isfile(onecrl_bin):
+            logger.critical("Go package `oneCRL2RevocationsTxt` is missing executable")
+            sys.exit(5)
+        onecrl_cmd = [onecrl_bin, "--env", onecrl_env]
+        logger.debug("Running shell command `%s`" % " ".join(onecrl_cmd))
+        try:
+            revocations_data = subprocess.check_output(onecrl_cmd, env=go_env)
+        except subprocess.CalledProcessError as error:
+            logger.critical("Could not fetch revocations data: %s" % error)
+            sys.exit(5)
+
+        # oneCRL2RevocationsTxt does not indicate failure, but the result is empty.
+        # Can we be sure this can never happen during regular operation?
+        # See https://github.com/mozmark/OneCRL-Tools/issues/3
+        if len(revocations_data) == 0:
+            logger.critical("Revocations data was empty. Likely network failure.")
+            sys.exit(5)
+
+        # Write OneCRL data to cache
+        logger.debug("Caching OneCRL revocations data in `%s`" % cache_file)
+        with open(cache_file, "w") as f:
+            f.write(revocations_data)
+
+    else:
+        logger.warning("Using cached OneCRL revocations data from `%s`" % cache_file)
+
+    return cache_file


### PR DESCRIPTION
Currently it re-downloads revocations.txt on every run although it hardly changes frequently.